### PR TITLE
Fixes SELinux complaining about volume label when using /src

### DIFF
--- a/preview.sh
+++ b/preview.sh
@@ -23,7 +23,7 @@ echo "***********************************************************"
 
 # Start Jekyll and watch for changes
 docker run --rm \
-  --volume=$(pwd):/src \
+  --volume=$(pwd):/src:Z \
   --publish 4000:4000 \
   $DOCKER_IMAGE_NAME \
   serve --watch --drafts -H 0.0.0.0


### PR DESCRIPTION
Had some issues on Fedora 24 Workstation when trying to run provision.sh, this should fix that and probably shouldn't affect other Linux distros

See http://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/ for more details
